### PR TITLE
#32 [FEAT]: Error formatter

### DIFF
--- a/src/controllers/addressController.ts
+++ b/src/controllers/addressController.ts
@@ -2,6 +2,7 @@ import { Response, Request } from 'express';
 import { Address } from '@prisma/client';
 import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
+import errorFormatter from '../services/errorFormatter';
 
 export const createAddress = async (req: Request, res: Response) => {
     try {
@@ -14,7 +15,7 @@ export const createAddress = async (req: Request, res: Response) => {
             })
             .noUnknown();
 
-        const address = await createAddressSchema.validate(req.body);
+        const address = await createAddressSchema.validate(req.body, { stripUnknown: false });
 
         const createdAddress: Address = await prismaClient.address.create({
             data: address,
@@ -22,7 +23,7 @@ export const createAddress = async (req: Request, res: Response) => {
 
         res.status(201).json({ message: 'Address created.', data: createdAddress });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -39,7 +40,7 @@ export const updateAddress = async (req: Request, res: Response): Promise<void> 
             })
             .noUnknown();
 
-        const address = await createAddressSchema.validate(req.body);
+        const address = await createAddressSchema.validate(req.body, { stripUnknown: false });
 
         const updatedAddress: Address = await prismaClient.address.update({
             where: {
@@ -50,7 +51,7 @@ export const updateAddress = async (req: Request, res: Response): Promise<void> 
 
         res.status(200).json({ message: 'Address updated.', data: updatedAddress });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -59,7 +60,7 @@ export const getAllAddresses = async (req: Request, res: Response): Promise<void
         const addresses: Address[] = await prismaClient.address.findMany();
         res.status(200).json({ message: 'All addresses found.', data: addresses });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -75,7 +76,7 @@ export const getAddress = async (req: Request, res: Response): Promise<void> => 
 
         res.status(200).json({ message: 'Address found.', data: address });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -91,6 +92,6 @@ export const deleteAddress = async (req: Request, res: Response): Promise<void> 
 
         res.status(200).json({ message: 'Address deleted.', data: deletedAddress });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };

--- a/src/controllers/applicationAnswerController.ts
+++ b/src/controllers/applicationAnswerController.ts
@@ -2,6 +2,7 @@ import { Response, Request } from 'express';
 import { ApplicationAnswer, User } from '@prisma/client';
 import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
+import errorFormatter from '../services/errorFormatter';
 
 export const createApplicationAnswer = async (req: Request, res: Response) => {
     try {
@@ -178,7 +179,7 @@ export const createApplicationAnswer = async (req: Request, res: Response) => {
         });
         res.status(201).json({ message: 'Application answer created.', data: createdApplicationAnswer });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -462,7 +463,7 @@ export const updateApplicationAnswer = async (req: Request, res: Response): Prom
         });
         res.status(200).json({ message: 'Application answer updated.', data: upsertedApplicationAnswer });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -508,7 +509,7 @@ export const getAllApplicationAnswers = async (req: Request, res: Response): Pro
                   });
         res.status(200).json({ message: 'All application answers found.', data: applicationAnswers });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -563,7 +564,7 @@ export const getApplicationAnswer = async (req: Request, res: Response): Promise
 
         res.status(200).json({ message: 'Application answer found.', data: applicationAnswer });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -592,6 +593,6 @@ export const deleteApplicationAnswer = async (req: Request, res: Response): Prom
 
         res.status(200).json({ message: 'Application answer deleted.', data: deletedApplicationAnswer });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };

--- a/src/controllers/applicationController.ts
+++ b/src/controllers/applicationController.ts
@@ -2,6 +2,7 @@ import { Response, Request } from 'express';
 import { Application, User, VisibilityMode } from '@prisma/client';
 import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
+import errorFormatter from '../services/errorFormatter';
 
 export const createApplication = async (req: Request, res: Response) => {
     try {
@@ -17,7 +18,7 @@ export const createApplication = async (req: Request, res: Response) => {
             .noUnknown();
 
         // Yup parsing/validation
-        const application = await createApplicationSchema.validate(req.body);
+        const application = await createApplicationSchema.validate(req.body, { stripUnknown: false });
 
         // User from Passport-JWT
         const user = req.user as User;
@@ -43,7 +44,7 @@ export const createApplication = async (req: Request, res: Response) => {
 
         res.status(201).json({ message: 'Application created.', data: createdApplication });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -64,7 +65,7 @@ export const updateApplication = async (req: Request, res: Response): Promise<vo
             .noUnknown();
 
         // Yup parsing/validation
-        const application = await updateApplicationSchema.validate(req.body);
+        const application = await updateApplicationSchema.validate(req.body, { stripUnknown: false });
 
         // User from Passport-JWT
         const user = req.user as User;
@@ -104,7 +105,7 @@ export const updateApplication = async (req: Request, res: Response): Promise<vo
 
         res.status(200).json({ message: 'Application updated.', data: updatedApplication });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -133,7 +134,7 @@ export const getAllApplications = async (req: Request, res: Response): Promise<v
                   });
         res.status(200).json({ message: 'All applicationes found.', data: applicationes });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -170,7 +171,7 @@ export const getApplication = async (req: Request, res: Response): Promise<void>
 
         res.status(200).json({ message: 'Application found.', data: application });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -199,6 +200,6 @@ export const deleteApplication = async (req: Request, res: Response): Promise<vo
 
         res.status(200).json({ message: 'Application deleted.', data: deletedApplication });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -3,6 +3,7 @@ import { User, UserRole } from '@prisma/client';
 import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
 import jwt from 'jsonwebtoken';
+import errorFormatter from '../services/errorFormatter';
 
 export const signUp = async (req: Request, res: Response) => {
     try {
@@ -39,7 +40,7 @@ export const signUp = async (req: Request, res: Response) => {
 
         res.status(201).json({ message: 'User signed up.', data: { id: createdUser.id, token: token } });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -71,6 +72,6 @@ export const signIn = async (req: Request, res: Response) => {
 
         res.status(200).json({ message: 'User signed in.', data: { id: user.id, token: token } });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };

--- a/src/services/errorFormatter.ts
+++ b/src/services/errorFormatter.ts
@@ -1,0 +1,9 @@
+export const errorFormatter = (error: any) => {
+    const message = error.message.split('\n');
+    return {
+        message: message[message.length - 1].charAt(0).toUpperCase() + message[message.length - 1].slice(1),
+        details: error,
+    };
+};
+
+export default errorFormatter;


### PR DESCRIPTION
**Implemented features**
- Error formatter that highlights the error message for any error format;
- Compatible with general, Prisma and Yup errors;

**Comments**
- Deviated from #9. I recommend prior review;
- Errors are formatted in a JSON object with the following attributes: message, with the error message, and details, with the original content of the error;
- For the time being, it does not support Passport errors and messages, as it is Middleware that runs before controllers;