### PR TITLE
#54 [FIX]: Removed explorer and disabled try it out for post, put, and delete methods

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,9 @@ app.use(
     '/api-docs',
     swaggerUi.serve,
     swaggerUi.setup(swaggerDocs, {
-        explorer: true,
+        swaggerOptions: {
+            supportedSubmitMethods: ['get'],
+        },
     })
 );
 


### PR DESCRIPTION
**Added corrections**
- Since Swagger UI does not correctly handle multipart/form-data requests, the "try it out" options have been removed for post, put and delete endpoints;
- The explore bar has been removed because it is not useful in our context;