### PR TITLE
#60 [FIX]: Refactoring of User, Address, Institution and Classroom endpoints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,7 +121,7 @@ model OptionAnswer {
   createdAt DateTime @default(now())
   updateAt  DateTime @updatedAt
 
-  text String
+  text String?
 
   itemId   Int
   item     Item            @relation(fields: [itemId], references: [id], onDelete: Cascade)
@@ -136,7 +136,7 @@ model TableAnswer {
   createdAt DateTime @default(now())
   updateAt  DateTime @updatedAt
 
-  text String
+  text String?
 
   itemId   Int
   item     Item            @relation(fields: [itemId], references: [id], onDelete: Cascade)

--- a/prisma/seeds/seed.ts
+++ b/prisma/seeds/seed.ts
@@ -70,6 +70,7 @@ async function main() {
             role: 'ADMIN' as UserRole,
             institutionId: 1,
             classrooms: [],
+            acceptedTerms: true,
         },
         {
             id: 2,
@@ -79,6 +80,7 @@ async function main() {
             role: 'ADMIN' as UserRole,
             institutionId: 1,
             classrooms: [],
+            acceptedTerms: true,
         },
         {
             id: 3,
@@ -88,6 +90,7 @@ async function main() {
             role: 'USER' as UserRole,
             institutionId: 2,
             classrooms: [1],
+            acceptedTerms: true,
         },
         {
             id: 4,
@@ -97,6 +100,7 @@ async function main() {
             role: 'USER' as UserRole,
             institutionId: 2,
             classrooms: [1],
+            acceptedTerms: true,
         },
     ];
 
@@ -106,12 +110,14 @@ async function main() {
             title: 'Protocol 1',
             description: 'Protocol 1 description',
             enabled: true,
+            applicable: true,
         },
         {
             id: 2,
             title: 'Protocol 2',
             description: 'Protocol 2 description',
             enabled: true,
+            applicable: true,
         },
     ];
 

--- a/prisma/seeds/seed.ts
+++ b/prisma/seeds/seed.ts
@@ -205,7 +205,7 @@ async function main() {
             groupId: 3,
             placement: 1,
             enabled: true,
-            type: 'SCALE' as ItemType,
+            type: 'SELECT' as ItemType,
         },
         {
             id: 4,
@@ -233,12 +233,24 @@ async function main() {
         },
         {
             id: 3,
+            text: 'Option 3.1',
+            placement: 1,
+            itemId: 3,
+        },
+        {
+            id: 4,
+            text: 'Option 3.2',
+            placement: 2,
+            itemId: 3,
+        },
+        {
+            id: 5,
             text: 'Option 4.1',
             placement: 1,
             itemId: 4,
         },
         {
-            id: 4,
+            id: 6,
             text: 'Option 4.2',
             placement: 2,
             itemId: 4,

--- a/src/app.ts
+++ b/src/app.ts
@@ -17,7 +17,9 @@ app.use(
     '/api-docs',
     swaggerUi.serve,
     swaggerUi.setup(swaggerDocs, {
-        explorer: true,
+        swaggerOptions: {
+            supportedSubmitMethods: ['get'],
+        },
     })
 );
 

--- a/src/controllers/addressController.ts
+++ b/src/controllers/addressController.ts
@@ -1,11 +1,21 @@
 import { Response, Request } from 'express';
-import { Address } from '@prisma/client';
+import { Address, User, UserRole } from '@prisma/client';
 import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
 import errorFormatter from '../services/errorFormatter';
 
+const checkAuthorization = (user: User) => {
+    if (user.role !== UserRole.ADMIN) {
+        throw new Error('This user is not authorized to perform this action');
+    }
+};
+
 export const createAddress = async (req: Request, res: Response) => {
     try {
+        const user = req.user as User;
+
+        checkAuthorization(user);
+
         const createAddressSchema = yup
             .object()
             .shape({
@@ -31,6 +41,10 @@ export const createAddress = async (req: Request, res: Response) => {
 export const updateAddress = async (req: Request, res: Response): Promise<void> => {
     try {
         const id: number = parseInt(req.params.addressId);
+
+        const user = req.user as User;
+
+        checkAuthorization(user);
 
         const updateAddressSchema = yup
             .object()
@@ -89,6 +103,10 @@ export const getAddress = async (req: Request, res: Response): Promise<void> => 
 export const deleteAddress = async (req: Request, res: Response): Promise<void> => {
     try {
         const id: number = parseInt(req.params.addressId);
+
+        const user = req.user as User;
+
+        checkAuthorization(user);
 
         const deletedAddress: Address = await prismaClient.address.delete({
             where: {

--- a/src/controllers/addressController.ts
+++ b/src/controllers/addressController.ts
@@ -4,6 +4,7 @@ import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
 import errorFormatter from '../services/errorFormatter';
 
+// Only admin can perform C-UD operations on addresses
 const checkAuthorization = (user: User) => {
     if (user.role !== UserRole.ADMIN) {
         throw new Error('This user is not authorized to perform this action');
@@ -12,10 +13,7 @@ const checkAuthorization = (user: User) => {
 
 export const createAddress = async (req: Request, res: Response) => {
     try {
-        const user = req.user as User;
-
-        checkAuthorization(user);
-
+        // Yup schemas
         const createAddressSchema = yup
             .object()
             .shape({
@@ -26,10 +24,17 @@ export const createAddress = async (req: Request, res: Response) => {
             })
             .noUnknown();
 
+        // Yup parsing/validation
         const address = await createAddressSchema.validate(req.body, { stripUnknown: false });
 
+        // User from Passport-JWT
+        const user = req.user as User;
+
+        // Check if user is authorized to create an address
+        checkAuthorization(user);
+        // Prisma operation
         const createdAddress: Address = await prismaClient.address.create({
-            data: address,
+            data: { id: address.id, city: address.city, state: address.state, country: address.country },
         });
 
         res.status(201).json({ message: 'Address created.', data: createdAddress });
@@ -40,33 +45,30 @@ export const createAddress = async (req: Request, res: Response) => {
 
 export const updateAddress = async (req: Request, res: Response): Promise<void> => {
     try {
+        // ID from params
         const id: number = parseInt(req.params.addressId);
 
-        const user = req.user as User;
-
-        checkAuthorization(user);
-
+        // Yup schemas
         const updateAddressSchema = yup
             .object()
-            .shape({
-                city: yup.string().min(1),
-                state: yup.string().min(1),
-                country: yup.string().min(1),
-            })
+            .shape({ city: yup.string().min(1), state: yup.string().min(1), country: yup.string().min(1) })
             .noUnknown();
 
+        // Yup parsing/validation
         const address = await updateAddressSchema.validate(req.body, { stripUnknown: false });
 
+        // User from Passport-JWT
+        const user = req.user as User;
+
+        // Check if user is authorized to update an address
+        checkAuthorization(user);
+
+        // Prisma operation
         const updatedAddress: Address = await prismaClient.address.update({
-            where: {
-                id,
-            },
-            data: {
-                city: address.city,
-                state: address.state,
-                country: address.country,
-            },
+            where: { id },
+            data: { city: address.city, state: address.state, country: address.country },
         });
+
         res.status(200).json({ message: 'Address updated.', data: updatedAddress });
     } catch (error: any) {
         res.status(400).json(errorFormatter(error));
@@ -75,7 +77,9 @@ export const updateAddress = async (req: Request, res: Response): Promise<void> 
 
 export const getAllAddresses = async (req: Request, res: Response): Promise<void> => {
     try {
+        // Prisma operation
         const addresses: Address[] = await prismaClient.address.findMany();
+
         res.status(200).json({ message: 'All addresses found.', data: addresses });
     } catch (error: any) {
         res.status(400).json(errorFormatter(error));
@@ -84,16 +88,12 @@ export const getAllAddresses = async (req: Request, res: Response): Promise<void
 
 export const getAddress = async (req: Request, res: Response): Promise<void> => {
     try {
+        // ID from params
         const id: number = parseInt(req.params.addressId);
 
-        const address: Address = await prismaClient.address.findUniqueOrThrow({
-            where: {
-                id,
-            },
-            include: {
-                institutions: true,
-            },
-        });
+        // Prisma operation
+        const address: Address = await prismaClient.address.findUniqueOrThrow({ where: { id } });
+
         res.status(200).json({ message: 'Address found.', data: address });
     } catch (error: any) {
         res.status(400).json(errorFormatter(error));
@@ -102,17 +102,18 @@ export const getAddress = async (req: Request, res: Response): Promise<void> => 
 
 export const deleteAddress = async (req: Request, res: Response): Promise<void> => {
     try {
+        // ID from params
         const id: number = parseInt(req.params.addressId);
 
+        // User from Passport-JWT
         const user = req.user as User;
 
+        // Check if user is authorized to delete an address
         checkAuthorization(user);
 
-        const deletedAddress: Address = await prismaClient.address.delete({
-            where: {
-                id,
-            },
-        });
+        // Prisma operation
+        const deletedAddress = await prismaClient.address.delete({ where: { id }, select: { id: true } });
+
         res.status(200).json({ message: 'Address deleted.', data: deletedAddress });
     } catch (error: any) {
         res.status(400).json(errorFormatter(error));

--- a/src/controllers/applicationAnswerController.ts
+++ b/src/controllers/applicationAnswerController.ts
@@ -53,7 +53,7 @@ export const createApplicationAnswer = async (req: Request, res: Response) => {
             .object()
             .shape({
                 id: yup.number(),
-                text: yup.string().min(3).max(255).required(),
+                text: yup.string().max(255),
                 itemId: yup.number().required(),
                 optionId: yup.number().required(),
             })
@@ -63,7 +63,7 @@ export const createApplicationAnswer = async (req: Request, res: Response) => {
             .object()
             .shape({
                 id: yup.number(),
-                text: yup.string().min(3).max(255).required(),
+                text: yup.string().max(255),
                 itemId: yup.number().required(),
                 columnId: yup.number().required(),
             })
@@ -73,9 +73,9 @@ export const createApplicationAnswer = async (req: Request, res: Response) => {
             .object()
             .shape({
                 id: yup.number(),
-                itemAnswers: yup.array().of(createItemAnswerSchema).required(),
-                tableAnswers: yup.array().of(createTableAnswerSchema).required(),
-                optionAnswers: yup.array().of(createOptionAnswerSchema).required(),
+                itemAnswers: yup.array().of(createItemAnswerSchema).default([]),
+                tableAnswers: yup.array().of(createTableAnswerSchema).default([]),
+                optionAnswers: yup.array().of(createOptionAnswerSchema).default([]),
             })
             .noUnknown();
 
@@ -195,21 +195,21 @@ export const updateApplicationAnswer = async (req: Request, res: Response): Prom
 
         const updateOptionAnswerSchema = yup
             .object()
-            .shape({ id: yup.number(), text: yup.string().min(3).max(255), itemId: yup.number().min(1), optionId: yup.number().min(1) })
+            .shape({ id: yup.number(), text: yup.string().max(255), itemId: yup.number().min(1), optionId: yup.number().min(1) })
             .noUnknown();
 
         const updateTableAnswerSchema = yup
             .object()
-            .shape({ id: yup.number(), text: yup.string().min(3).max(255), itemId: yup.number().min(1), columnId: yup.number().min(1) })
+            .shape({ id: yup.number(), text: yup.string().max(255), itemId: yup.number().min(1), columnId: yup.number().min(1) })
             .noUnknown();
 
         const updateItemAnswerGroupSchema = yup
             .object()
             .shape({
                 id: yup.number(),
-                itemAnswers: yup.array().of(updateItemAnswerSchema).required(),
-                tableAnswers: yup.array().of(updateTableAnswerSchema).required(),
-                optionAnswers: yup.array().of(updateOptionAnswerSchema).required(),
+                itemAnswers: yup.array().of(updateItemAnswerSchema).default([]),
+                tableAnswers: yup.array().of(updateTableAnswerSchema).default([]),
+                optionAnswers: yup.array().of(updateOptionAnswerSchema).default([]),
             })
             .noUnknown();
 

--- a/src/controllers/applicationAnswerController.ts
+++ b/src/controllers/applicationAnswerController.ts
@@ -23,7 +23,7 @@ const checkAuthorizationToAnswer = async (user: User, applicationId: number) => 
     }
 };
 
-const selectedFieldsWithNested = {
+const fieldsWithNesting = {
     id: true,
     date: true,
     userId: true,
@@ -167,7 +167,7 @@ export const createApplicationAnswer = async (req: Request, res: Response) => {
             // Return the created application answer with nested content included
             return await prisma.applicationAnswer.findUnique({
                 where: { id: createdApplicationAnswer.id },
-                select: selectedFieldsWithNested,
+                select: fieldsWithNesting,
             });
         });
 
@@ -356,7 +356,7 @@ export const updateApplicationAnswer = async (req: Request, res: Response): Prom
                 }
             }
             // Return the updated application answer with nested content included
-            return await prisma.applicationAnswer.findUnique({ where: { id }, select: selectedFieldsWithNested });
+            return await prisma.applicationAnswer.findUnique({ where: { id }, select: fieldsWithNesting });
         });
         res.status(200).json({ message: 'Application answer updated.', data: upsertedApplicationAnswer });
     } catch (error: any) {
@@ -372,8 +372,8 @@ export const getAllApplicationAnswers = async (req: Request, res: Response): Pro
         // Get all application answers with nested content included (only those that the user is allowed to view)
         const applicationAnswers: ApplicationAnswer[] =
             user.role === 'ADMIN'
-                ? await prismaClient.applicationAnswer.findMany({ select: selectedFieldsWithNested })
-                : await prismaClient.applicationAnswer.findMany({ where: { userId: user.id }, select: selectedFieldsWithNested });
+                ? await prismaClient.applicationAnswer.findMany({ select: fieldsWithNesting })
+                : await prismaClient.applicationAnswer.findMany({ where: { userId: user.id }, select: fieldsWithNesting });
 
         res.status(200).json({ message: 'All application answers found.', data: applicationAnswers });
     } catch (error: any) {
@@ -392,10 +392,10 @@ export const getApplicationAnswer = async (req: Request, res: Response): Promise
         // Get application answer with nested content included (only if user is allowed to view it or is admin)
         const applicationAnswer: ApplicationAnswer =
             user.role === 'ADMIN'
-                ? await prismaClient.applicationAnswer.findUniqueOrThrow({ where: { id }, select: selectedFieldsWithNested })
+                ? await prismaClient.applicationAnswer.findUniqueOrThrow({ where: { id }, select: fieldsWithNesting })
                 : await prismaClient.applicationAnswer.findUniqueOrThrow({
                       where: { id, userId: user.id },
-                      select: selectedFieldsWithNested,
+                      select: fieldsWithNesting,
                   });
 
         res.status(200).json({ message: 'Application answer found.', data: applicationAnswer });

--- a/src/controllers/applicationController.ts
+++ b/src/controllers/applicationController.ts
@@ -36,7 +36,7 @@ const validateVisibleFields = async (user: User, application: any) => {
     return application;
 };
 
-const selectedFields = {
+const fieldsWithNesting = {
     id: true,
     protocol: { select: { id: true, title: true, description: true } },
     visibilityMode: true,
@@ -46,13 +46,13 @@ const selectedFields = {
 };
 
 const fieldsWithViewers = {
-    ...selectedFields,
+    ...fieldsWithNesting,
     viewersUser: { select: { id: true, username: true } },
     viewersClassroom: { select: { id: true, institution: { select: { name: true } } } },
 };
 
 const fieldsWithFullProtocol = {
-    ...selectedFields,
+    ...fieldsWithNesting,
     protocol: {
         include: {
             pages: {
@@ -217,7 +217,7 @@ export const getVisibleApplications = async (req: Request, res: Response): Promi
                               { applicatorId: user.id },
                           ],
                       },
-                      select: selectedFields,
+                      select: fieldsWithNesting,
                   });
         res.status(200).json({ message: 'All visible applications found.', data: applications });
     } catch (error: any) {

--- a/src/controllers/applicationController.ts
+++ b/src/controllers/applicationController.ts
@@ -115,7 +115,7 @@ export const getAllApplications = async (req: Request, res: Response): Promise<v
         const user = req.user as User;
 
         // Get all applications that the user is allowed to see
-        const applicationes: Application[] =
+        const applications: Application[] =
             user.role === 'ADMIN'
                 ? await prismaClient.application.findMany({
                       include: {
@@ -132,7 +132,38 @@ export const getAllApplications = async (req: Request, res: Response): Promise<v
                           viewersClassroom: true,
                       },
                   });
-        res.status(200).json({ message: 'All applicationes found.', data: applicationes });
+        res.status(200).json({ message: 'All applications found.', data: applications });
+    } catch (error: any) {
+        res.status(400).json(errorFormatter(error));
+    }
+};
+
+export const getAllApplicationsWithProtocol = async (req: Request, res: Response): Promise<void> => {
+    try {
+        // User from Passport-JWT
+        const user = req.user as User;
+
+        // Get all applications that the user is allowed to see
+        const applications: Application[] =
+            user.role === 'ADMIN'
+                ? await prismaClient.application.findMany({
+                      include: {
+                          viewersUser: true,
+                          viewersClassroom: true,
+                          protocol: true,
+                      },
+                  })
+                : await prismaClient.application.findMany({
+                      where: {
+                          applicatorId: user.id,
+                      },
+                      include: {
+                          viewersUser: true,
+                          viewersClassroom: true,
+                          protocol: true,
+                      },
+                  });
+        res.status(200).json({ message: 'All applications found.', data: applications });
     } catch (error: any) {
         res.status(400).json(errorFormatter(error));
     }
@@ -166,6 +197,89 @@ export const getApplication = async (req: Request, res: Response): Promise<void>
                       include: {
                           viewersUser: true,
                           viewersClassroom: true,
+                      },
+                  });
+
+        res.status(200).json({ message: 'Application found.', data: application });
+    } catch (error: any) {
+        res.status(400).json(errorFormatter(error));
+    }
+};
+
+export const getApplicationWithProtocol = async (req: Request, res: Response): Promise<void> => {
+    try {
+        // ID from params
+        const id: number = parseInt(req.params.applicationId);
+
+        // User from Passport-JWT
+        const user = req.user as User;
+
+        // Get the application if the user is allowed to see it
+        const application: Application =
+            user.role === 'ADMIN'
+                ? await prismaClient.application.findUniqueOrThrow({
+                      where: {
+                          id: id,
+                      },
+                      include: {
+                          viewersUser: true,
+                          viewersClassroom: true,
+                          protocol: {
+                              include: {
+                                  pages: {
+                                      include: {
+                                          itemGroups: {
+                                              include: {
+                                                  items: {
+                                                      include: {
+                                                          itemOptions: {
+                                                              include: {
+                                                                  files: true,
+                                                              },
+                                                          },
+                                                          itemValidations: true,
+                                                          files: true,
+                                                      },
+                                                  },
+                                              },
+                                          },
+                                      },
+                                  },
+                              },
+                          },
+                      },
+                  })
+                : await prismaClient.application.findUniqueOrThrow({
+                      where: {
+                          id: id,
+                          applicatorId: user.id,
+                      },
+                      include: {
+                          viewersUser: true,
+                          viewersClassroom: true,
+                          protocol: {
+                              include: {
+                                  pages: {
+                                      include: {
+                                          itemGroups: {
+                                              include: {
+                                                  items: {
+                                                      include: {
+                                                          itemOptions: {
+                                                              include: {
+                                                                  files: true,
+                                                              },
+                                                          },
+                                                          itemValidations: true,
+                                                          files: true,
+                                                      },
+                                                  },
+                                              },
+                                          },
+                                      },
+                                  },
+                              },
+                          },
                       },
                   });
 

--- a/src/controllers/classroomController.ts
+++ b/src/controllers/classroomController.ts
@@ -4,6 +4,7 @@ import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
 import errorFormatter from '../services/errorFormatter';
 
+// Fields to be selected from the database to the response
 const fieldsWithNesting = {
     id: true,
     institution: {
@@ -23,6 +24,7 @@ const fieldsWithNesting = {
     updateAt: true,
 };
 
+// Only admins or the coordinator of the institution can perform C-UD operations on classrooms
 const checkAuthorization = (user: User, institutionId: number) => {
     if (user.role !== 'ADMIN' && (user.role !== 'COORDINATOR' || user.institutionId !== institutionId)) {
         throw new Error('This user is not authorized to perform this action');
@@ -31,26 +33,31 @@ const checkAuthorization = (user: User, institutionId: number) => {
 
 export const createClassroom = async (req: Request, res: Response) => {
     try {
+        // Yup schemas
         const createClassroomSchema = yup
             .object()
             .shape({
+                id: yup.number().min(1),
                 institutionId: yup.number().required(),
                 users: yup.array().of(yup.number()).min(2).required(),
             })
             .noUnknown();
 
+        // Yup parsing/validation
         const classroom = await createClassroomSchema.validate(req.body);
 
+        // User from Passport-JWT
         const user = req.user as User;
 
+        // Check if user is authorized to create a classroom
         checkAuthorization(user, classroom.institutionId);
 
+        // Prisma operation
         const createdClassroom: Classroom = await prismaClient.classroom.create({
             data: {
+                id: classroom.id,
                 institutionId: classroom.institutionId,
-                users: {
-                    connect: classroom.users.map((id) => ({ id: id })),
-                },
+                users: { connect: classroom.users.map((id) => ({ id: id })) },
             },
         });
 
@@ -62,8 +69,10 @@ export const createClassroom = async (req: Request, res: Response) => {
 
 export const updateClassroom = async (req: Request, res: Response): Promise<void> => {
     try {
+        // ID from params
         const id: number = parseInt(req.params.classroomId);
 
+        // Yup schemas
         const updateClassroomSchema = yup
             .object()
             .shape({
@@ -71,23 +80,25 @@ export const updateClassroom = async (req: Request, res: Response): Promise<void
             })
             .noUnknown();
 
+        // Yup parsing/validation
         const classroom = await updateClassroomSchema.validate(req.body);
 
+        // User from Passport-JWT
         const user = req.user as User;
 
-        const updatedClassroom = await prismaClient.classroom.update({
-            where: {
-                id,
-                institutionId: user.institutionId as number,
-            },
-            data: {
-                users: {
-                    set: [],
-                    connect: classroom.users?.map((id) => ({ id: id })),
-                },
-            },
-            select: fieldsWithNesting,
-        });
+        // Prisma operation with authorization check - admin can update all classrooms, coordinator can update only their institution classrooms
+        const updatedClassroom =
+            user.role === UserRole.ADMIN
+                ? await prismaClient.classroom.update({
+                      where: { id },
+                      data: { users: { set: [], connect: classroom.users?.map((id) => ({ id: id })) } },
+                      select: fieldsWithNesting,
+                  })
+                : await prismaClient.classroom.update({
+                      where: { id, institutionId: user.institutionId as number },
+                      data: { users: { set: [], connect: classroom.users?.map((id) => ({ id: id })) } },
+                      select: fieldsWithNesting,
+                  });
 
         res.status(200).json({ message: 'Classroom updated.', data: updatedClassroom });
     } catch (error: any) {
@@ -97,19 +108,20 @@ export const updateClassroom = async (req: Request, res: Response): Promise<void
 
 export const getAllClassrooms = async (req: Request, res: Response): Promise<void> => {
     try {
+        // User from Passport-JWT
         const user = req.user as User;
 
+        // Check if user is authorized to get all classrooms (only roles above USER)
         if (user.role === UserRole.USER) {
             throw new Error('This user is not authorized to perform this action');
         }
 
+        // Prisma operation with authorization check - admin can see all classrooms, coordinator can see only their institution classrooms
         const classrooms =
             user.role === UserRole.ADMIN
                 ? await prismaClient.classroom.findMany({ select: fieldsWithNesting })
                 : await prismaClient.classroom.findMany({
-                      where: {
-                          institutionId: user.institutionId as number,
-                      },
+                      where: { institutionId: user.institutionId as number },
                       select: fieldsWithNesting,
                   });
 
@@ -121,21 +133,22 @@ export const getAllClassrooms = async (req: Request, res: Response): Promise<voi
 
 export const getClassroom = async (req: Request, res: Response): Promise<void> => {
     try {
+        // ID from params
         const id: number = parseInt(req.params.classroomId);
 
+        // User from Passport-JWT
         const user = req.user as User;
 
+        // Prisma operation with authorization check - admin can see all classrooms, coordinator can see only their institution classrooms
         const classroom =
             user.role === UserRole.ADMIN
                 ? await prismaClient.classroom.findUniqueOrThrow({ where: { id }, select: fieldsWithNesting })
                 : await prismaClient.classroom.findUniqueOrThrow({
-                      where: {
-                          id,
-                          institutionId: user.institutionId as number,
-                      },
+                      where: { id, institutionId: user.institutionId as number },
                       select: fieldsWithNesting,
                   });
 
+        // Check if user with role user is authorized to get this classroom (only users in the classroom)
         if (user.role === UserRole.USER && !classroom.users?.some((user) => user.id === user.id)) {
             throw new Error('This user is not authorized to perform this action');
         }
@@ -148,17 +161,17 @@ export const getClassroom = async (req: Request, res: Response): Promise<void> =
 
 export const deleteClassroom = async (req: Request, res: Response): Promise<void> => {
     try {
+        // ID from params
         const id: number = parseInt(req.params.classroomId);
 
+        // User from Passport-JWT
         const user = req.user as User;
 
-        const deletedClassroom = await prismaClient.classroom.delete({
-            where: {
-                id,
-                institutionId: user.institutionId as number,
-            },
-            select: { id: true },
-        });
+        // Prisma operation with authorization check - admin can delete all classrooms, coordinator can delete only their institution classrooms
+        const deletedClassroom =
+            user.role === UserRole.ADMIN
+                ? await prismaClient.classroom.delete({ where: { id }, select: { id: true } })
+                : await prismaClient.classroom.delete({ where: { id, institutionId: user.institutionId as number }, select: { id: true } });
 
         res.status(200).json({ message: 'Classroom deleted.', data: deletedClassroom });
     } catch (error: any) {

--- a/src/controllers/institutionController.ts
+++ b/src/controllers/institutionController.ts
@@ -1,13 +1,42 @@
 import { Response, Request } from 'express';
-import { Institution, InstitutionType } from '@prisma/client';
+import { InstitutionType, User } from '@prisma/client';
 import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
+import errorFormatter from '../services/errorFormatter';
+
+const fieldsWithNesting = {
+    id: true,
+    name: true,
+    type: true,
+    address: {
+        select: {
+            id: true,
+            city: true,
+            state: true,
+            country: true,
+        },
+    },
+    classrooms: {
+        select: {
+            id: true,
+        },
+    },
+    createdAt: true,
+    updateAt: true,
+};
+
+const checkAuthorization = (user: User, id: number) => {
+    if (user.role !== 'ADMIN' && (user.institutionId !== id || user.role !== 'COORDINATOR')) {
+        throw new Error('This user is not authorized to perform this action');
+    }
+};
 
 export const createInstitution = async (req: Request, res: Response) => {
     try {
         const createInstitutionSchema = yup
             .object()
             .shape({
+                id: yup.number(),
                 name: yup.string().min(1).max(255).required(),
                 type: yup.string().oneOf(Object.values(InstitutionType)).required(),
                 addressId: yup.number().required(),
@@ -16,13 +45,25 @@ export const createInstitution = async (req: Request, res: Response) => {
 
         const institution = await createInstitutionSchema.validate(req.body);
 
-        const createdInstitution: Institution = await prismaClient.institution.create({
-            data: institution,
+        const user = req.user as User;
+
+        if (user.role !== 'ADMIN') {
+            throw new Error('This user is not authorized to perform this action');
+        }
+
+        const createdInstitution = await prismaClient.institution.create({
+            data: {
+                id: institution.id,
+                name: institution.name,
+                type: institution.type,
+                addressId: institution.addressId,
+            },
+            select: fieldsWithNesting,
         });
 
         res.status(201).json({ message: 'Institution created.', data: createdInstitution });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -36,13 +77,16 @@ export const updateInstitution = async (req: Request, res: Response): Promise<vo
                 name: yup.string().min(1).max(255),
                 type: yup.string().oneOf(Object.values(InstitutionType)),
                 addressId: yup.number(),
-                classrooms: yup.array().of(yup.number()),
             })
             .noUnknown();
 
         const institution = await updateInstitutionSchema.validate(req.body);
 
-        const updatedInstitution: Institution = await prismaClient.institution.update({
+        const user = req.user as User;
+
+        checkAuthorization(user, id);
+
+        const updatedInstitution = await prismaClient.institution.update({
             where: {
                 id,
             },
@@ -51,21 +95,28 @@ export const updateInstitution = async (req: Request, res: Response): Promise<vo
                 type: institution.type,
                 addressId: institution.addressId,
             },
+            select: fieldsWithNesting,
         });
 
         res.status(200).json({ message: 'Institution updated.', data: updatedInstitution });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
 export const getAllInstitutions = async (req: Request, res: Response): Promise<void> => {
     try {
-        const institutions: Institution[] = await prismaClient.institution.findMany({});
+        const user = req.user as User;
+
+        if (user.role !== 'ADMIN') {
+            throw new Error('This user is not authorized to perform this action');
+        }
+
+        const institutions = await prismaClient.institution.findMany({ select: fieldsWithNesting });
 
         res.status(200).json({ message: 'All institutions found.', data: institutions });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -73,18 +124,20 @@ export const getInstitution = async (req: Request, res: Response): Promise<void>
     try {
         const id: number = parseInt(req.params.institutionId);
 
-        const institution: Institution = await prismaClient.institution.findUniqueOrThrow({
+        const user = req.user as User;
+
+        checkAuthorization(user, id);
+
+        const institution = await prismaClient.institution.findUniqueOrThrow({
             where: {
                 id,
             },
-            include: {
-                classrooms: true,
-            },
+            select: fieldsWithNesting,
         });
 
         res.status(200).json({ message: 'Institution found.', data: institution });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -92,14 +145,17 @@ export const deleteInstitution = async (req: Request, res: Response): Promise<vo
     try {
         const id: number = parseInt(req.params.institutionId);
 
-        const deletedInstitution: Institution = await prismaClient.institution.delete({
-            where: {
-                id,
-            },
+        const user = req.user as User;
+
+        checkAuthorization(user, id);
+
+        const deletedInstitution = await prismaClient.institution.delete({
+            where: { id },
+            select: { id: true },
         });
 
         res.status(200).json({ message: 'Institution deleted.', data: deletedInstitution });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -2,6 +2,44 @@ import { Response, Request } from 'express';
 import { User, UserRole } from '@prisma/client';
 import * as yup from 'yup';
 import prismaClient from '../services/prismaClient';
+import errorFormatter from '../services/errorFormatter';
+
+const checkAuthorization = (user: User, id: number) => {
+    if (user.role !== UserRole.ADMIN && user.id !== id) {
+        throw new Error('This user is not authorized to perform this action');
+    }
+};
+
+const checkHierarchy = (user: User, role: UserRole) => {
+    const coordinatorRestrictions = user.role === UserRole.COORDINATOR && (role === UserRole.ADMIN || role === UserRole.COORDINATOR);
+    const publisherRestrictions =
+        user.role === UserRole.PUBLISHER &&
+        (role === UserRole.ADMIN || role === UserRole.COORDINATOR || role === UserRole.PUBLISHER || role === UserRole.APLICATOR);
+    const otherRestrictions = user.role === UserRole.APLICATOR || user.role === UserRole.USER;
+
+    if (coordinatorRestrictions || publisherRestrictions || otherRestrictions) {
+        throw new Error('This user is not authorized to perform this action');
+    }
+};
+
+const fieldsWithNesting = {
+    name: true,
+    username: true,
+    role: true,
+    institution: {
+        select: {
+            id: true,
+            name: true,
+        },
+    },
+    classrooms: {
+        select: {
+            id: true,
+        },
+    },
+    createdAt: true,
+    updateAt: true,
+};
 
 export const createUser = async (req: Request, res: Response) => {
     try {
@@ -19,7 +57,11 @@ export const createUser = async (req: Request, res: Response) => {
 
         const user = await createUserSchema.validate(req.body);
 
-        const createdUser: User = await prismaClient.user.create({
+        const curUser = req.user as User;
+
+        checkHierarchy(curUser, user.role);
+
+        const createdUser = await prismaClient.user.create({
             data: {
                 name: user.name,
                 username: user.username,
@@ -27,11 +69,12 @@ export const createUser = async (req: Request, res: Response) => {
                 role: user.role,
                 institutionId: user.institutionId,
             },
+            select: fieldsWithNesting,
         });
 
         res.status(201).json({ message: 'User created.', data: createdUser });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -53,7 +96,11 @@ export const updateUser = async (req: Request, res: Response): Promise<void> => 
 
         const user = await updateUserSchema.validate(req.body);
 
-        const updatedUser: User = await prismaClient.user.update({
+        const curUser = req.user as User;
+
+        checkAuthorization(curUser, id);
+
+        const updatedUser = await prismaClient.user.update({
             where: {
                 id,
             },
@@ -67,21 +114,24 @@ export const updateUser = async (req: Request, res: Response): Promise<void> => 
                     disconnect: user.classrooms?.map((id) => ({ id: id })),
                 },
             },
+            select: fieldsWithNesting,
         });
 
         res.status(200).json({ message: 'User updated.', data: updatedUser });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
 export const getAllUsers = async (req: Request, res: Response): Promise<void> => {
     try {
-        const users: User[] = await prismaClient.user.findMany({});
+        if ((req.user as User).role !== UserRole.ADMIN) throw new Error('This user is not authorized to perform this action');
+
+        const users = await prismaClient.user.findMany({ select: fieldsWithNesting });
 
         res.status(200).json({ message: 'All users found.', data: users });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -89,18 +139,20 @@ export const getUser = async (req: Request, res: Response): Promise<void> => {
     try {
         const id: number = parseInt(req.params.userId);
 
-        const user: User = await prismaClient.user.findUniqueOrThrow({
+        const curUser = req.user as User;
+
+        checkAuthorization(curUser, id);
+
+        const user = await prismaClient.user.findUniqueOrThrow({
             where: {
                 id,
             },
-            include: {
-                classrooms: true,
-            },
+            select: fieldsWithNesting,
         });
 
         res.status(200).json({ message: 'User found.', data: user });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };
 
@@ -108,14 +160,21 @@ export const deleteUser = async (req: Request, res: Response): Promise<void> => 
     try {
         const id: number = parseInt(req.params.userId);
 
-        const deletedUser: User = await prismaClient.user.delete({
+        const curUser = req.user as User;
+
+        checkAuthorization(curUser, id);
+
+        const deletedUser = await prismaClient.user.delete({
             where: {
                 id,
+            },
+            select: {
+                id: true,
             },
         });
 
         res.status(200).json({ message: 'User deleted.', data: deletedUser });
     } catch (error: any) {
-        res.status(400).json({ error: error });
+        res.status(400).json(errorFormatter(error));
     }
 };

--- a/src/routes/addressRoutes.ts
+++ b/src/routes/addressRoutes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import uploader from '../services/multerUploader';
 import { createAddress, updateAddress, getAllAddresses, getAddress, deleteAddress } from '../controllers/addressController';
+import passport from '../services/passportAuth';
 
 const router = express.Router();
 
@@ -68,7 +69,7 @@ const router = express.Router();
  *               type: string
  *               description: Error message
  */
-router.post('/createAddress', uploader.none(), createAddress);
+router.post('/createAddress', passport.authenticate('jwt', { session: false }), uploader.none(), createAddress);
 
 /**
  * @swagger
@@ -112,7 +113,7 @@ router.post('/createAddress', uploader.none(), createAddress);
  *               type: string
  *               description: Error message
  */
-router.put('/updateAddress/:addressId', uploader.none(), updateAddress);
+router.put('/updateAddress/:addressId', passport.authenticate('jwt', { session: false }), uploader.none(), updateAddress);
 
 /**
  * @swagger
@@ -138,7 +139,7 @@ router.put('/updateAddress/:addressId', uploader.none(), updateAddress);
  *               type: string
  *               description: Error message
  */
-router.get('/getAllAddresses', uploader.none(), getAllAddresses);
+router.get('/getAllAddresses', passport.authenticate('jwt', { session: false }), uploader.none(), getAllAddresses);
 
 /**
  * @swagger
@@ -176,7 +177,7 @@ router.get('/getAllAddresses', uploader.none(), getAllAddresses);
  *               type: string
  *               description: Error message
  */
-router.get('/getAddress/:addressId', uploader.none(), getAddress);
+router.get('/getAddress/:addressId', passport.authenticate('jwt', { session: false }), uploader.none(), getAddress);
 
 /**
  * @swagger
@@ -214,6 +215,6 @@ router.get('/getAddress/:addressId', uploader.none(), getAddress);
  *               type: string
  *               description: Error message
  */
-router.delete('/deleteAddress/:addressId', uploader.none(), deleteAddress);
+router.delete('/deleteAddress/:addressId', passport.authenticate('jwt', { session: false }), uploader.none(), deleteAddress);
 
 export default router;

--- a/src/routes/applicationRoutes.ts
+++ b/src/routes/applicationRoutes.ts
@@ -6,7 +6,6 @@ import {
     getAllApplications,
     getApplication,
     deleteApplication,
-    getAllApplicationsWithProtocol,
     getApplicationWithProtocol,
 } from '../controllers/applicationController';
 import passport from '../services/passportAuth';
@@ -173,39 +172,6 @@ router.put('/updateApplication/:applicationId', passport.authenticate('jwt', { s
  *               description: Error message
  */
 router.get('/getAllApplications', passport.authenticate('jwt', { session: false }), uploader.none(), getAllApplications);
-
-/**
- * @swagger
- * /api/application/getAllApplicationsWithProtocol:
- *   get:
- *     summary: Get all applications with nested protocols
- *     tags: [Application]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: The list of applications was successfully retrieved
- *         content:
- *           application/json:
- *             message: All applications found.
- *             data:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Application'
- *       500:
- *         description: An error occurred while retrieving the list of applications
- *         content:
- *           application/json:
- *             error:
- *               type: string
- *               description: Error message
- */
-router.get(
-    '/getAllApplicationsWithProtocol',
-    passport.authenticate('jwt', { session: false }),
-    uploader.none(),
-    getAllApplicationsWithProtocol
-);
 
 /**
  * @swagger

--- a/src/routes/applicationRoutes.ts
+++ b/src/routes/applicationRoutes.ts
@@ -3,7 +3,8 @@ import uploader from '../services/multerUploader';
 import {
     createApplication,
     updateApplication,
-    getAllApplications,
+    getMyApplications,
+    getVisibleApplications,
     getApplication,
     deleteApplication,
     getApplicationWithProtocol,
@@ -147,9 +148,9 @@ router.put('/updateApplication/:applicationId', passport.authenticate('jwt', { s
 
 /**
  * @swagger
- * /api/application/getAllApplications:
+ * /api/application/getMyApplications:
  *   get:
- *     summary: Get all applications
+ *     summary: Get all applications created by the user
  *     tags: [Application]
  *     security:
  *       - bearerAuth: []
@@ -171,7 +172,35 @@ router.put('/updateApplication/:applicationId', passport.authenticate('jwt', { s
  *               type: string
  *               description: Error message
  */
-router.get('/getAllApplications', passport.authenticate('jwt', { session: false }), uploader.none(), getAllApplications);
+router.get('/getMyApplications', passport.authenticate('jwt', { session: false }), uploader.none(), getMyApplications);
+
+/**
+ * @swagger
+ * /api/application/getVisibleApplications:
+ *   get:
+ *     summary: Get all applications that are visible to the user
+ *     tags: [Application]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The list of applications was successfully retrieved
+ *         content:
+ *           application/json:
+ *             message: All applications found.
+ *             data:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Application'
+ *       500:
+ *         description: An error occurred while retrieving the list of applications
+ *         content:
+ *           application/json:
+ *             error:
+ *               type: string
+ *               description: Error message
+ */
+router.get('/getVisibleApplications', passport.authenticate('jwt', { session: false }), uploader.none(), getVisibleApplications);
 
 /**
  * @swagger

--- a/src/routes/applicationRoutes.ts
+++ b/src/routes/applicationRoutes.ts
@@ -6,6 +6,8 @@ import {
     getAllApplications,
     getApplication,
     deleteApplication,
+    getAllApplicationsWithProtocol,
+    getApplicationWithProtocol,
 } from '../controllers/applicationController';
 import passport from '../services/passportAuth';
 
@@ -174,6 +176,39 @@ router.get('/getAllApplications', passport.authenticate('jwt', { session: false 
 
 /**
  * @swagger
+ * /api/application/getAllApplicationsWithProtocol:
+ *   get:
+ *     summary: Get all applications with nested protocols
+ *     tags: [Application]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The list of applications was successfully retrieved
+ *         content:
+ *           application/json:
+ *             message: All applications found.
+ *             data:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Application'
+ *       500:
+ *         description: An error occurred while retrieving the list of applications
+ *         content:
+ *           application/json:
+ *             error:
+ *               type: string
+ *               description: Error message
+ */
+router.get(
+    '/getAllApplicationsWithProtocol',
+    passport.authenticate('jwt', { session: false }),
+    uploader.none(),
+    getAllApplicationsWithProtocol
+);
+
+/**
+ * @swagger
  * /api/application/getApplication/{applicationId}:
  *   get:
  *     summary: Get an application by id
@@ -211,6 +246,51 @@ router.get('/getAllApplications', passport.authenticate('jwt', { session: false 
  *               description: Error message
  */
 router.get('/getApplication/:applicationId', passport.authenticate('jwt', { session: false }), uploader.none(), getApplication);
+
+/**
+ * @swagger
+ * /api/application/getApplicationWithProtocol/{applicationId}:
+ *   get:
+ *     summary: Get an application by id with nested protocol
+ *     tags: [Application]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: applicationId
+ *         schema:
+ *           type: integer
+ *         required: true
+ *         description: The id of the application to retrieve
+ *     responses:
+ *       200:
+ *         description: The application was successfully retrieved
+ *         content:
+ *           application/json:
+ *             message: Application found.
+ *             data:
+ *               $ref: '#/components/schemas/Application'
+ *       400:
+ *         description: An application with the specified id was not found
+ *         content:
+ *           application/json:
+ *             error:
+ *               type: string
+ *               description: Error message
+ *       500:
+ *         description: An error occurred while retrieving the application
+ *         content:
+ *           application/json:
+ *             error:
+ *               type: string
+ *               description: Error message
+ */
+router.get(
+    '/getApplicationWithProtocol/:applicationId',
+    passport.authenticate('jwt', { session: false }),
+    uploader.none(),
+    getApplicationWithProtocol
+);
 
 /**
  * @swagger

--- a/src/routes/classroomRoutes.ts
+++ b/src/routes/classroomRoutes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import uploader from '../services/multerUploader';
 import { createClassroom, updateClassroom, getAllClassrooms, getClassroom, deleteClassroom } from '../controllers/classroomController';
+import passport from '../services/passportAuth';
 
 /**
  * @swagger
@@ -64,7 +65,7 @@ const router = express.Router();
  *               data:
  *                 $ref: '#/components/schemas/Classroom'
  */
-router.post('/createClassroom', uploader.none(), createClassroom);
+router.post('/createClassroom', passport.authenticate('jwt', { session: false }), uploader.none(), createClassroom);
 
 /**
  * @swagger
@@ -110,7 +111,7 @@ router.post('/createClassroom', uploader.none(), createClassroom);
  *               data:
  *                 $ref: '#/components/schemas/Classroom'
  */
-router.put('/updateClassroom/:classroomId', uploader.none(), updateClassroom);
+router.put('/updateClassroom/:classroomId', passport.authenticate('jwt', { session: false }), uploader.none(), updateClassroom);
 
 /**
  * @swagger
@@ -134,7 +135,7 @@ router.put('/updateClassroom/:classroomId', uploader.none(), updateClassroom);
  *            data:
  *              $ref: '#/components/schemas/Classroom'
  */
-router.get('/getAllClassrooms', uploader.none(), getAllClassrooms);
+router.get('/getAllClassrooms', passport.authenticate('jwt', { session: false }), uploader.none(), getAllClassrooms);
 
 /**
  * @swagger
@@ -174,7 +175,7 @@ router.get('/getAllClassrooms', uploader.none(), getAllClassrooms);
  *              data:
  *                $ref: '#/components/schemas/Classroom'
  */
-router.get('/getClassroom/:classroomId', uploader.none(), getClassroom);
+router.get('/getClassroom/:classroomId', passport.authenticate('jwt', { session: false }), uploader.none(), getClassroom);
 
 /**
  * @swagger
@@ -214,6 +215,6 @@ router.get('/getClassroom/:classroomId', uploader.none(), getClassroom);
  *              data:
  *                $ref: '#/components/schemas/Classroom'
  */
-router.delete('/deleteClassroom/:classroomId', uploader.none(), deleteClassroom);
+router.delete('/deleteClassroom/:classroomId', passport.authenticate('jwt', { session: false }), uploader.none(), deleteClassroom);
 
 export default router;

--- a/src/routes/institutionRoutes.ts
+++ b/src/routes/institutionRoutes.ts
@@ -7,6 +7,7 @@ import {
     getInstitution,
     deleteInstitution,
 } from '../controllers/institutionController';
+import passport from '../services/passportAuth';
 
 /**
  * @swagger
@@ -73,7 +74,7 @@ const router = express.Router();
  *             error:
  *               message: error message
  */
-router.post('/createInstitution', uploader.none(), createInstitution);
+router.post('/createInstitution', passport.authenticate('jwt', { session: false }), uploader.none(), createInstitution);
 
 /**
  * @swagger
@@ -115,7 +116,7 @@ router.post('/createInstitution', uploader.none(), createInstitution);
  *             error:
  *               message: error message
  */
-router.put('/updateInstitution/:institutionId', uploader.none(), updateInstitution);
+router.put('/updateInstitution/:institutionId', passport.authenticate('jwt', { session: false }), uploader.none(), updateInstitution);
 
 /**
  * @swagger
@@ -140,7 +141,7 @@ router.put('/updateInstitution/:institutionId', uploader.none(), updateInstituti
  *             error:
  *               message: error message
  */
-router.get('/getAllInstitutions', uploader.none(), getAllInstitutions);
+router.get('/getAllInstitutions', passport.authenticate('jwt', { session: false }), uploader.none(), getAllInstitutions);
 
 /**
  * @swagger
@@ -174,7 +175,7 @@ router.get('/getAllInstitutions', uploader.none(), getAllInstitutions);
  *           application/json:
  *             message: error message
  */
-router.get('/getInstitution/:institutionId', uploader.none(), getInstitution);
+router.get('/getInstitution/:institutionId', passport.authenticate('jwt', { session: false }), uploader.none(), getInstitution);
 
 /**
  * @swagger
@@ -208,6 +209,6 @@ router.get('/getInstitution/:institutionId', uploader.none(), getInstitution);
  *           application/json:
  *             message: error message
  */
-router.delete('/deleteInstitution/:institutionId', uploader.none(), deleteInstitution);
+router.delete('/deleteInstitution/:institutionId', passport.authenticate('jwt', { session: false }), uploader.none(), deleteInstitution);
 
 export default router;

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import uploader from '../services/multerUploader';
 import { createUser, updateUser, getAllUsers, getUser, deleteUser } from '../controllers/userController';
+import passport from '../services/passportAuth';
 
 /**
  * @swagger
@@ -80,7 +81,7 @@ const router = express.Router();
  *              data:
  *                $ref: '#/components/schemas/User'
  */
-router.post('/createUser', uploader.none(), createUser);
+router.post('/createUser', passport.authenticate('jwt', { session: false }), uploader.none(), createUser);
 
 /**
  * @swagger
@@ -126,7 +127,7 @@ router.post('/createUser', uploader.none(), createUser);
  *              data:
  *                $ref: '#/components/schemas/User'
  */
-router.put('/updateUser/:userId', uploader.none(), updateUser);
+router.put('/updateUser/:userId', passport.authenticate('jwt', { session: false }), uploader.none(), updateUser);
 
 /**
  * @swagger
@@ -149,7 +150,7 @@ router.put('/updateUser/:userId', uploader.none(), updateUser);
  *             error:
  *               message: error message
  */
-router.get('/getAllUsers', uploader.none(), getAllUsers);
+router.get('/getAllUsers', passport.authenticate('jwt', { session: false }), uploader.none(), getAllUsers);
 
 /**
  * @swagger
@@ -187,7 +188,7 @@ router.get('/getAllUsers', uploader.none(), getAllUsers);
  *               type: string
  *               description: Error message
  */
-router.get('/getUser/:userId', uploader.none(), getUser);
+router.get('/getUser/:userId', passport.authenticate('jwt', { session: false }), uploader.none(), getUser);
 
 /**
  * @swagger
@@ -227,6 +228,6 @@ router.get('/getUser/:userId', uploader.none(), getUser);
  *              data:
  *                $ref: '#/components/schemas/User'
  */
-router.delete('/deleteUser/:userId', uploader.none(), deleteUser);
+router.delete('/deleteUser/:userId', passport.authenticate('jwt', { session: false }), uploader.none(), deleteUser);
 
 export default router;


### PR DESCRIPTION
**Added refactorings**
- Authentication on User, Address, Institution and Classroom endpoints;
- Added errorFormatter on endpoints that didn't use it;
- Organized the fields that each endpoint must return, adding relevant fields and removing sensitive/dispensable ones;
- Added authorization checks (some require team validation);
- Branch diverted from all branches with pending pull requests before it.

**Authorizations added**
- Only admins perform CRUD operations in Address;
- Only admins create institutions and only institution coordinators (and admins) can handle them;
- Coordinators can only be created by admins. Publishers and applicators can only be created by coordinators and admins. Users can only be created by publishers, coordinators and admins;
- Classrooms can only be created and handled by admins or coordinators of the institution and viewed by admins and other members of the institution (excluding users);