### PR TITLE
#146 [FIX]: Protocol update rules compatible with moving items between pages and groups

### DIFF
--- a/src/controllers/protocolController.ts
+++ b/src/controllers/protocolController.ts
@@ -1227,7 +1227,12 @@ export const updateProtocol = async (req: Request, res: Response): Promise<void>
             // Remove itemGroups that are not in the updated page
             await prisma.itemGroup.deleteMany({
                 where: {
-                    id: { notIn: protocol.pages.flatMap((page) => page.itemGroups).map((itemGroup) => itemGroup.id as number) },
+                    id: {
+                        notIn: protocol.pages
+                            .flatMap((page) => page.itemGroups)
+                            .filter((itemGroup) => itemGroup.id)
+                            .map(({ id }) => id as number),
+                    },
                     page: { protocolId: id },
                 },
             });
@@ -1238,7 +1243,8 @@ export const updateProtocol = async (req: Request, res: Response): Promise<void>
                         notIn: protocol.pages
                             .flatMap((page) => page.itemGroups)
                             .flatMap((itemGroup) => itemGroup.tableColumns)
-                            .map((tableColumn) => tableColumn.id as number),
+                            .filter((tableColumn) => tableColumn.id)
+                            .map(({ id }) => id as number),
                     },
                     itemGroup: { page: { protocolId: id } },
                 },
@@ -1250,7 +1256,8 @@ export const updateProtocol = async (req: Request, res: Response): Promise<void>
                         notIn: protocol.pages
                             .flatMap((page) => page.itemGroups)
                             .flatMap((itemGroup) => itemGroup.items)
-                            .map((item) => item.id as number),
+                            .filter((item) => item.id)
+                            .map(({ id }) => id as number),
                     },
                     itemGroup: { page: { protocolId: id } },
                 },


### PR DESCRIPTION
This pull request includes significant changes to the `updateProtocol` function in `src/controllers/protocolController.ts` to improve the handling of deletions and moves (changing the relationship with a parent object) for pages, itemGroups, tableColumns, and items. The changes ensure that deletions and updates are compatible with the possibility of changing an item's page and group.

To achieve this, it was necessary to relax the update restrictions (restricting editing not only to items in a group or groups on a page, but now only checking their membership in that protocol) and deletion restrictions (removing only items and groups that were not received in the protocol as a whole, not just in a specific group or page). Finally, it was necessary to move the deletion functions for pages, groups, items, and tableColumns to after creation and deletion, to prevent deleting existing objects from implying the deletion of nested objects that will no longer be affiliated with them.

Key changes include:

* **Refactoring deletion logic:**
  - Removed the deletion of pages, itemGroups, tableColumns, and items from their respective update sections and moved them to the end of the `updateProtocol` function. [[1]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L963-L969) [[2]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L984-R988) [[3]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L1012-R1004) [[4]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L1041-L1047) [[5]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L1058-R1032)

* **Consolidated deletion operations:**
  - Added consolidated deletion operations for pages, itemGroups, tableColumns, and items that are not present in the updated protocol..