### PR TITLE
#148 [FIX]: Yup validations updated to reject unknown properties

### DIFF
--- a/src/controllers/addressController.ts
+++ b/src/controllers/addressController.ts
@@ -110,7 +110,8 @@ export const getAddressesByState = async (req: Request, res: Response): Promise<
         // Yup schemas
         const getAddressesByStateSchema = yup
             .object()
-            .shape({ state: yup.string().min(1).required(), country: yup.string().min(1).required() });
+            .shape({ state: yup.string().min(1).required(), country: yup.string().min(1).required() })
+            .noUnknown();
         // Yup parsing/validation
         const searchParams = await getAddressesByStateSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT
@@ -132,11 +133,14 @@ export const getAddressesByState = async (req: Request, res: Response): Promise<
 export const getAddressId = async (req: Request, res: Response): Promise<void> => {
     try {
         // Yup schemas
-        const getCityIdSchema = yup.object().shape({
-            city: yup.string().min(1).required(),
-            state: yup.string().min(1).required(),
-            country: yup.string().min(1).required(),
-        });
+        const getCityIdSchema = yup
+            .object()
+            .shape({
+                city: yup.string().min(1).required(),
+                state: yup.string().min(1).required(),
+                country: yup.string().min(1).required(),
+            })
+            .noUnknown();
         // Yup parsing/validation
         const searchParams = await getCityIdSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT

--- a/src/controllers/classroomController.ts
+++ b/src/controllers/classroomController.ts
@@ -142,7 +142,7 @@ export const createClassroom = async (req: Request, res: Response) => {
             })
             .noUnknown();
         // Yup parsing/validation
-        const classroom = await createClassroomSchema.validate(req.body);
+        const classroom = await createClassroomSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT
         const user = req.user as User;
         // Check if user is authorized to create a classroom
@@ -177,11 +177,11 @@ export const updateClassroom = async (req: Request, res: Response): Promise<void
             .shape({
                 name: yup.string().min(3).max(20),
                 institutionId: yup.number(),
-                users: yup.array().of(yup.number()).min(2),
+                users: yup.array().of(yup.number()).min(2).required(),
             })
             .noUnknown();
         // Yup parsing/validation
-        const classroom = await updateClassroomSchema.validate(req.body);
+        const classroom = await updateClassroomSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT
         const user = req.user as User;
         // Check if user is authorized to update this classroom
@@ -316,7 +316,7 @@ export const searchClassroomByName = async (req: Request, res: Response): Promis
             .shape({ term: yup.string().min(3).max(20).required() })
             .noUnknown();
         // Yup parsing/validation
-        const { term } = await searchUserSchema.validate(req.body);
+        const { term } = await searchUserSchema.validate(req.body, { stripUnknown: false });
         // Prisma operation
         const classrooms = await prismaClient.classroom.findMany({
             where: {

--- a/src/controllers/institutionController.ts
+++ b/src/controllers/institutionController.ts
@@ -108,7 +108,7 @@ export const createInstitution = async (req: Request, res: Response) => {
             })
             .noUnknown();
         // Yup parsing/validation
-        const institution = await createInstitutionSchema.validate(req.body);
+        const institution = await createInstitutionSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT
         const user = req.user as User;
         // Check if user is authorized to create an institution
@@ -156,7 +156,7 @@ export const updateInstitution = async (req: Request, res: Response): Promise<vo
             })
             .noUnknown();
         // Yup parsing/validation
-        const institution = await updateInstitutionSchema.validate(req.body);
+        const institution = await updateInstitutionSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT
         const user = req.user as User;
         // Check if user is authorized to update an institution

--- a/src/controllers/protocolController.ts
+++ b/src/controllers/protocolController.ts
@@ -619,7 +619,7 @@ export const createProtocol = async (req: Request, res: Response) => {
             })
             .noUnknown();
         // Yup parsing/validation
-        const protocol = await createProtocolSchema.validate(req.body, { stripUnknown: true });
+        const protocol = await createProtocolSchema.validate(req.body, { stripUnknown: false });
         // Sort elements by placement
         for (const page of protocol.pages) {
             page.itemGroups.sort((a, b) => a.placement - b.placement);
@@ -907,7 +907,7 @@ export const updateProtocol = async (req: Request, res: Response): Promise<void>
             })
             .noUnknown();
         // Yup parsing/validation
-        const protocol = await updateProtocolSchema.validate(req.body, { stripUnknown: true });
+        const protocol = await updateProtocolSchema.validate(req.body, { stripUnknown: false });
         // Sort elements by placement
         for (const page of protocol.pages) {
             page.itemGroups.sort((a, b) => a.placement - b.placement);

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -183,7 +183,7 @@ export const createUser = async (req: Request, res: Response) => {
             })
             .noUnknown();
         // Yup parsing/validation
-        const user = await createUserSchema.validate(req.body);
+        const user = await createUserSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT
         const curUser = req.user as User;
         // Check if user is authorized to create a user
@@ -232,12 +232,12 @@ export const updateUser = async (req: Request, res: Response): Promise<void> => 
                 hash: yup.string(),
                 role: yup.string().oneOf(Object.values(UserRole)),
                 institutionId: yup.number(),
-                classrooms: yup.array().of(yup.number()),
+                classrooms: yup.array().of(yup.number()).default([]),
                 profileImageId: yup.number(),
             })
             .noUnknown();
         // Yup parsing/validation
-        const user = await updateUserSchema.validate(req.body);
+        const user = await updateUserSchema.validate(req.body, { stripUnknown: false });
         // User from Passport-JWT
         const curUser = req.user as User;
         // Check if user is authorized to update the user
@@ -367,7 +367,7 @@ export const searchUserByUsername = async (req: Request, res: Response): Promise
             .shape({ term: yup.string().min(3).max(20).required() })
             .noUnknown();
         // Yup parsing/validation
-        const { term } = await searchUserSchema.validate(req.body);
+        const { term } = await searchUserSchema.validate(req.body, { stripUnknown: false });
         // Prisma operation
         const users = await prismaClient.user.findMany({
             where: {


### PR DESCRIPTION
This pull request includes several updates to the validation logic across multiple controllers to ensure unknown fields are not allowed and to adjust the `stripUnknown` option in the Yup validation schemas.

Validation improvements:

* [`src/controllers/addressController.ts`](diffhunk://#diff-b5ce3d210063adeda4cfca81152d50c4947849850ed018aa24563a3341ad5e8cL113-R114): Added `.noUnknown()` to the `getAddressesByStateSchema` and `getCityIdSchema` to disallow unknown fields in the request body. [[1]](diffhunk://#diff-b5ce3d210063adeda4cfca81152d50c4947849850ed018aa24563a3341ad5e8cL113-R114) [[2]](diffhunk://#diff-b5ce3d210063adeda4cfca81152d50c4947849850ed018aa24563a3341ad5e8cL135-R143)

* [`src/controllers/classroomController.ts`](diffhunk://#diff-1616f3519ecbc14f7d8f889f330d5abb68abecfedd0ea40d903fddf2ccb24a56L145-R145): Updated the Yup validation schemas to include `.noUnknown()` and modified the `stripUnknown` option to `false` for `createClassroomSchema`, `updateClassroomSchema`, and `searchUserSchema`. [[1]](diffhunk://#diff-1616f3519ecbc14f7d8f889f330d5abb68abecfedd0ea40d903fddf2ccb24a56L145-R145) [[2]](diffhunk://#diff-1616f3519ecbc14f7d8f889f330d5abb68abecfedd0ea40d903fddf2ccb24a56L180-R184) [[3]](diffhunk://#diff-1616f3519ecbc14f7d8f889f330d5abb68abecfedd0ea40d903fddf2ccb24a56L319-R319)

* [`src/controllers/institutionController.ts`](diffhunk://#diff-7e35765f7d0bf87e7d10ad1ec0870dc3718d17c51ef5cb6942da3159154f71d8L111-R111): Added `.noUnknown()` to the validation schemas and set `stripUnknown` to `false` for `createInstitutionSchema` and `updateInstitutionSchema`. [[1]](diffhunk://#diff-7e35765f7d0bf87e7d10ad1ec0870dc3718d17c51ef5cb6942da3159154f71d8L111-R111) [[2]](diffhunk://#diff-7e35765f7d0bf87e7d10ad1ec0870dc3718d17c51ef5cb6942da3159154f71d8L159-R159)

* [`src/controllers/protocolController.ts`](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L622-R622): Ensured unknown fields are not allowed by setting `stripUnknown` to `false` in the `createProtocolSchema` and `updateProtocolSchema`. [[1]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L622-R622) [[2]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L910-R910)

* [`src/controllers/userController.ts`](diffhunk://#diff-93f38a6cb6e392b8a89d567802a053a184eb506c7db929b4962617b7cd4c9372L186-R186): Updated the Yup validation schemas to include `.noUnknown()` and set `stripUnknown` to `false` for `createUserSchema`, `updateUserSchema`, and `searchUserSchema`. [[1]](diffhunk://#diff-93f38a6cb6e392b8a89d567802a053a184eb506c7db929b4962617b7cd4c9372L186-R186) [[2]](diffhunk://#diff-93f38a6cb6e392b8a89d567802a053a184eb506c7db929b4962617b7cd4c9372L235-R240) [[3]](diffhunk://#diff-93f38a6cb6e392b8a89d567802a053a184eb506c7db929b4962617b7cd4c9372L370-R370)