### PR TITLE
#150 [FIX]: Disjoint conditions for obtaining protocols in the getMyProtocols endpoint

### DIFF
--- a/src/controllers/protocolController.ts
+++ b/src/controllers/protocolController.ts
@@ -1301,14 +1301,13 @@ export const getVisibleProtocols = async (req: Request, res: Response): Promise<
                       where: {
                           OR: [
                               { managers: { some: { id: user.id } } },
-                              { appliers: { some: { id: user.id } } },
-                              { viewersUser: { some: { id: user.id } } },
-                              { viewersClassroom: { some: { users: { some: { id: user.id } } } } },
+                              { appliers: { some: { id: user.id } }, enabled: true },
+                              { viewersUser: { some: { id: user.id } }, enabled: true },
+                              { viewersClassroom: { some: { users: { some: { id: user.id } } } }, enabled: true },
                               { creatorId: user.id },
-                              { visibility: VisibilityMode.PUBLIC },
+                              { visibility: VisibilityMode.PUBLIC, enabled: true },
                               ...(user.role === UserRole.COORDINATOR ? [{ creator: { institutionId: user.institutionId } }] : []),
                           ],
-                          enabled: true,
                       },
                       select: fields,
                   });
@@ -1335,7 +1334,7 @@ export const getMyProtocols = async (req: Request, res: Response): Promise<void>
         const user = req.user as User;
         // Prisma operation
         const protocols = await prismaClient.protocol.findMany({
-            where: { OR: [{ managers: { some: { id: user.id } }, creatorId: user.id }] },
+            where: { OR: [{ managers: { some: { id: user.id } } }, { creatorId: user.id }] },
             select: fieldsWViewers,
         });
         // Embed user actions in the response


### PR DESCRIPTION
This pull request fixes the filtering logic in `protocolController` to include `enabled: true` conditions for protocols in the correct scope, and fixes a minor logic error in the query for fetching user-specific protocols.

### Updates to filtering logic:
* [`src/controllers/protocolController.ts`](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L1304-L1311): The `enabled: true` condition has been removed from the top level and added only to the lower levels where it is relevant, i.e. for `appliers`, `viewersUser`, `viewersClassroom`, and `visibility: PUBLIC`. Consequently, viewers in other conditions are able to see the disabled protocols.=

### Fix in user-specific protocol query:
* [`src/controllers/protocolController.ts`](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L1338-R1337): Fixed the logical structure in the `getMyProtocols` function, separating the conditions for `managers` and `creatorId` in the `OR` clause, ensuring correct, more relaxed filtering.