### PR TITLE
#157 [FIX]: Enhance dependency validation logic and update schema to allow optional arguments

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@
 // of the GNU General Public License along with PICCE-API.  If not, see <https://www.gnu.org/licenses/>
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["native", "linux-musl-openssl-3.0.x"]
 }
 
@@ -212,8 +212,8 @@ model User {
   createdClassrooms         Classroom[]         @relation(name: "ClassroomCreator") // classrooms that the user has created
   createdUsers              User[]              @relation(name: "UserCreator") // users that the user has created
 
-  creatorId Int?
-  creator  User? @relation(name: "UserCreator", fields: [creatorId], references: [id], onDelete: SetNull)
+  creatorId     Int?
+  creator       User?        @relation(name: "UserCreator", fields: [creatorId], references: [id], onDelete: SetNull)
   institutionId Int?
   institution   Institution? @relation(fields: [institutionId], references: [id], onDelete: SetNull)
 }
@@ -408,7 +408,7 @@ model ItemGroupDependencyRule {
   updatedAt DateTime @updatedAt
 
   type          DependencyType
-  argument      String
+  argument      String?
   customMessage String?
 
   itemGroupId Int
@@ -425,7 +425,7 @@ model PageDependencyRule {
   updatedAt DateTime @updatedAt
 
   type          DependencyType
-  argument      String
+  argument      String?
   customMessage String?
 
   pageId Int

--- a/src/controllers/protocolController.ts
+++ b/src/controllers/protocolController.ts
@@ -344,6 +344,23 @@ const validatePlacements = async (placements: number[]) => {
     }
 };
 
+const validateDependency = async (type: DependencyType, argument: string = '') => {
+    switch (type) {
+        case DependencyType.EXACT_ANSWER:
+        case DependencyType.OPTION_SELECTED:
+            if (argument.length === 0) throw new Error('Option selected and exact answer dependencies must have an argument.');
+        case DependencyType.MIN:
+        case DependencyType.MAX:
+            if (Number.isNaN(parseInt(argument))) throw new Error('Min and max dependencies must have a numeric argument.');
+            break;
+        case DependencyType.IS_ANSWERED:
+            if (argument.length > 0) throw new Error('Is answered dependency must not have an argument.');
+            break;
+        default:
+            throw new Error('Invalid dependency type.');
+    }
+};
+
 const dropSensitiveFields = (protocol: any) => {
     const filteredProtocol = { ...protocol };
     delete filteredProtocol.managers;
@@ -555,7 +572,7 @@ export const createProtocol = async (req: Request, res: Response) => {
             .object()
             .shape({
                 type: yup.mixed<DependencyType>().oneOf(Object.values(DependencyType)).required(),
-                argument: yup.string().required(),
+                argument: yup.string(),
                 customMessage: yup.string(),
                 itemTempId: yup.number().min(1).required(),
             })
@@ -757,6 +774,8 @@ export const createProtocol = async (req: Request, res: Response) => {
                         }
                     }
                     for (const [dependencyId, dependency] of itemGroup.dependencies.entries()) {
+                        // Validate dependency type and argument
+                        await validateDependency(dependency.type, dependency.argument);
                         const createdDependency = await prisma.itemGroupDependencyRule.create({
                             data: {
                                 type: dependency.type,
@@ -769,6 +788,8 @@ export const createProtocol = async (req: Request, res: Response) => {
                     }
                 }
                 for (const [dependencyId, dependency] of page.dependencies.entries()) {
+                    // Validate dependency type and argument
+                    await validateDependency(dependency.type, dependency.argument);
                     const createdDependency = await prisma.pageDependencyRule.create({
                         data: {
                             type: dependency.type,
@@ -840,7 +861,7 @@ export const updateProtocol = async (req: Request, res: Response): Promise<void>
             .shape({
                 id: yup.number().min(1),
                 type: yup.mixed<DependencyType>().oneOf(Object.values(DependencyType)).required(),
-                argument: yup.string().required(),
+                argument: yup.string(),
                 customMessage: yup.string(),
                 itemTempId: yup.number().min(1).required(),
             })
@@ -1179,6 +1200,8 @@ export const updateProtocol = async (req: Request, res: Response): Promise<void>
                     });
                     // Update existing dependencies or create new ones
                     for (const [dependencyId, dependency] of itemGroup.dependencies.entries()) {
+                        // Validate dependency type and argument
+                        await validateDependency(dependency.type, dependency.argument);
                         const upsertedDependency = dependency.id
                             ? await prisma.itemGroupDependencyRule.update({
                                   where: { id: dependency.id, itemGroupId: upsertedItemGroup.id },
@@ -1209,6 +1232,8 @@ export const updateProtocol = async (req: Request, res: Response): Promise<void>
                 });
                 // Update existing dependencies or create new ones
                 for (const [dependencyId, dependency] of page.dependencies.entries()) {
+                    // Validate dependency type and argument
+                    await validateDependency(dependency.type, dependency.argument);
                     const upsertedDependency = dependency.id
                         ? await prisma.pageDependencyRule.update({
                               where: { id: dependency.id, pageId: upsertedPage.id },

--- a/src/controllers/protocolController.ts
+++ b/src/controllers/protocolController.ts
@@ -349,6 +349,7 @@ const validateDependency = async (type: DependencyType, argument: string = '') =
         case DependencyType.EXACT_ANSWER:
         case DependencyType.OPTION_SELECTED:
             if (argument.length === 0) throw new Error('Option selected and exact answer dependencies must have an argument.');
+            break;
         case DependencyType.MIN:
         case DependencyType.MAX:
             if (Number.isNaN(parseInt(argument))) throw new Error('Min and max dependencies must have a numeric argument.');


### PR DESCRIPTION
This pull request introduces changes to improve dependency validation and update the database schema to allow optional arguments for dependency rules. The most significant changes include adding a new validation function for dependency types and arguments, modifying schema fields to make `argument` optional, and integrating the validation function into protocol creation and update workflows.

### Validation Enhancements:
* Added a new `validateDependency` function to enforce rules for dependency types and their arguments, ensuring proper validation for cases like numeric arguments for `MIN`/`MAX` or no arguments for `IS_ANSWERED`. (`src/controllers/protocolController.ts`, [src/controllers/protocolController.tsR347-R363](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90R347-R363))

* Integrated the `validateDependency` function into the `createProtocol` and `updateProtocol` workflows to validate dependency rules before they are persisted to the database. (`src/controllers/protocolController.ts`, [[1]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90R777-R778) [[2]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90R791-R792) [[3]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90R1203-R1204) [[4]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90R1235-R1236)

### Schema Updates:
* Updated the `ItemGroupDependencyRule` and `PageDependencyRule` models in the Prisma schema to make the `argument` field optional (`String?`), reflecting the new validation logic. (`prisma/schema.prisma`, [[1]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL411-R411) [[2]](diffhunk://#diff-5b443964f4f3a611682db8f7e02177b0a8c632b2039e2bd5e4dd7347815c565cL428-R428)

### Validation Schema Adjustments:
* Modified the Yup validation schema for dependency rules in both `createProtocol` and `updateProtocol` to make the `argument` field optional. (`src/controllers/protocolController.ts`, [[1]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L558-R575) [[2]](diffhunk://#diff-3aa998c6ab78402367a9df5ac61ccd490fa7a97a5cdd9b3c4b35cd1fd97c2f90L843-R864)